### PR TITLE
add accessor dash to regex

### DIFF
--- a/lib/patterns.js
+++ b/lib/patterns.js
@@ -6,7 +6,7 @@
  */
 const patterns = {
 
-  accessor: /^[a-zA-Z_$][a-zA-Z0-9_$]*$/,
+  accessor: /^[a-zA-Z_$][a-zA-Z0-9-_$]*$/,
 
   index: /^\[([0-9]+)]$/,
 


### PR DESCRIPTION
Lmk your thoughts!  

The problem is if a key has a dash `key-other`, we can't call `create` on the object.